### PR TITLE
testdrive: Initialize testdrive user via URL

### DIFF
--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -336,19 +336,27 @@ impl State {
             }
         }
 
+        // Alter materialize user with all attributes.
+        inner_client
+            .batch_execute(&format!(
+                "ALTER ROLE {} WITH CREATEDB CREATECLUSTER CREATEROLE",
+                self.materialize_user
+            ))
+            .await?;
+
         // Grant initial privileges.
         inner_client
             .batch_execute("GRANT USAGE ON DATABASE materialize TO PUBLIC")
             .await?;
         inner_client
             .batch_execute(&format!(
-                "GRANT CREATE ON DATABASE materialize TO {}",
+                "GRANT ALL PRIVILEGES ON DATABASE materialize TO {}",
                 self.materialize_user
             ))
             .await?;
         inner_client
             .batch_execute(&format!(
-                "GRANT CREATE ON SCHEMA materialize.public TO {}",
+                "GRANT ALL PRIVILEGES ON SCHEMA materialize.public TO {}",
                 self.materialize_user
             ))
             .await?;
@@ -357,7 +365,7 @@ impl State {
             .await?;
         inner_client
             .batch_execute(&format!(
-                "GRANT CREATE ON CLUSTER default TO {}",
+                "GRANT ALL PRIVILEGES ON CLUSTER default TO {}",
                 self.materialize_user
             ))
             .await?;
@@ -668,12 +676,11 @@ pub async fn create_state(
                 .context("setting session parameter")?;
         }
 
-        // Old versions of Materialize did not support `current_user`, so we
-        // fail gracefully.
-        let materialize_user = match pgclient.query_one("SELECT current_user", &[]).await {
-            Ok(row) => row.get(0),
-            Err(_) => "<unknown user>".to_owned(),
-        };
+        let materialize_user = config
+            .materialize_pgconfig
+            .get_user()
+            .expect("testdrive URL must contain user")
+            .to_string();
 
         let materialize_sql_addr = format!(
             "{}:{}",

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -44,6 +44,7 @@ class Generator:
         )
         print("DROP SCHEMA IF EXISTS public CASCADE;")
         print(f"CREATE SCHEMA public /* {cls} */;")
+        print("GRANT ALL PRIVILEGES ON SCHEMA public TO materialize")
         print(
             "$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}"
         )
@@ -1314,7 +1315,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                     WORKERS {args.workers}
                 )
             )
-        """
+        """,
+            port=6877,
+            user="mz_system",
         )
 
         c.up("testdrive", persistent=True)

--- a/test/sql-feature-flags/mzcompose.py
+++ b/test/sql-feature-flags/mzcompose.py
@@ -44,6 +44,7 @@ def header(test_name: str, drop_schema: bool) -> str:
             $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
             DROP SCHEMA IF EXISTS public CASCADE;
             CREATE SCHEMA public /* {test_name} */;
+            GRANT ALL PRIVILEGES ON SCHEMA public TO materialize;
             """
         )
     # Create connections.


### PR DESCRIPTION
This commit updates the logic for initializing the testdrive SQL user to parse the user out of the PostgreSQL URL instead of querying `SELECT current_user;`. The query requires the default cluster to exist and for the materialize user to have USAGE privileges on that cluster. If a test deletes the default cluster or revokes privileges from it, then testdrive will stop working.

Fixes MaterializeInc/database-issues#5733

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
